### PR TITLE
Add missing content type header for token post request.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,9 @@ const getRequestOptions = (
 
   if (token_in_body) {
     options.body = qs.stringify(params)
+    options.headers = {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
   } else {
     options.qs = params
   }


### PR DESCRIPTION
This is a necessary header to make it work with some oidc providers namely https://github.com/panva/node-oidc-provider